### PR TITLE
Convert import to require

### DIFF
--- a/HelloWorld/configure_android_test_app.ts
+++ b/HelloWorld/configure_android_test_app.ts
@@ -1,7 +1,7 @@
-import childProcess from "child_process";
-import path from "path";
-
 exports.run = function () {
+  const childProcess = require("child_process");
+  const path = require("path");
+
   const expectedProjectPath = path.resolve(
     __dirname,
     "../apps/android/LwcTestApp"

--- a/HelloWorld/configure_ios_test_app.ts
+++ b/HelloWorld/configure_ios_test_app.ts
@@ -1,7 +1,7 @@
-import childProcess from "child_process";
-import path from "path";
-
 exports.run = function () {
+  const childProcess = require("child_process");
+  const path = require("path");
+
   const expectedProjectPath = path.resolve(
     __dirname,
     "../apps/ios/LwcTestApp/LwcTestApp.xcodeproj"


### PR DESCRIPTION
Having `import` statements outside the `run()` function throws off the `force:lightning:lwc:preview` command, causing it to error out with this message: `Cannot use import statement outside a module`

So instead we're going to use `require` statements inside the `run()` function to avoid this issue.