### PR TITLE
accept all licenses

### DIFF
--- a/HelloWorld/configure_android_test_app.ts
+++ b/HelloWorld/configure_android_test_app.ts
@@ -23,6 +23,10 @@ exports.run = function () {
     // with the use of BufferedReader in Java and piping YES into STDIN.
     // The workaround is to create a temporary file with a bunch of YES
     // in it, then feed that file to SDKManager and then delete that file.
+    //
+    // The format of the temporary file is very important. The file should have
+    // the letter y per line with no leading/trailing spaces, and the file must
+    // not end with any blank lines or spaces.
     const yesFileCommand =
       `CMD /Q /C "FOR /L %G IN (1,1,49) DO (echo y)>>output-yes-file.txt" & echo|set /p="y">>output-yes-file.txt`;
     const acceptCommand = `${sdkmanager} --licenses < output-yes-file.txt`;


### PR DESCRIPTION
Allow SDKManager to determine all licenses that have not been accepted and then accept them all.